### PR TITLE
secret: add ipv4 address to secret for non proxy usage

### DIFF
--- a/secret.tf
+++ b/secret.tf
@@ -6,6 +6,7 @@ resource "kubernetes_secret" "credential_secret" {
   }
 
   data = {
+    address  = google_sql_database_instance.instance.ip_address.0.ip_address
     instance = google_sql_database_instance.instance.connection_name
     database = google_sql_database.database[count.index].name
     username = google_sql_user.database_user[count.index].name


### PR DESCRIPTION
Related: bulderbank/cloud-setup#686

Add IPv4 address to generated secret, for database connections without cloudsql proxy
