### PR TITLE
terraform: prevent update-in-place every plan/apply due to deprecated…

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -24,4 +24,11 @@ resource "google_sql_database_instance" "instance" {
       update_track = "stable"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      settings[0].replication_type
+    ]
+  }
 }
+


### PR DESCRIPTION
Terraform wants to update the database instances every single plan/apply, but there aren't any changes.
It looks like Terraform is derping over `settings.replication_type`, a deprecated settings field:

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#replication_type

Probably a bug in the Terraform provider, but updating to latest version doesn't resolve the problem, so I'm just adding a lifecycle ignore to stop this issue from spamming our Terraform plans in CircleCi.